### PR TITLE
Some terrible hacks

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,67 +1,29 @@
-#include <iostream>
-#include <squeeze/squeeze.h>
+#include "../include/squeeze/squeeze.h"
 
 
-
-
-constinit
-auto table = squeeze::StringTable([]{
-    return std::to_array<std::string_view>({
-        "There is little point to using short strings in a compressed string table.",
-        "We will include some long strings in the table to test it."
-    });
-});
-
-enum class StringName
-{
+enum class Key {
     String_1,
     String_2,
-    String_3,
-    String_4,
+    String_3
 };
 
-constinit
-auto map = squeeze::StringMap<StringName>([]{
-    return std::to_array<squeeze::KeyedStringView<StringName>>(
-    {
-        // out of order, and not all keys provided
-        {StringName::String_4, "This is string 4"},
-        {StringName::String_1, "This is string 1"},
-        {StringName::String_2, "This is string 2"},
+static constexpr auto buildMapStrings = [] {
+    return std::to_array<squeeze::KeyedStringView<Key>>({
+      // out of order and missing a value
+      { Key::String_3, "There is little point to using short strings in a compressed string table." },
+      { Key::String_1, "We will include some long strings in the table to test it." },
     });
-});
+};
 
+void putc(const char c) ;
 
-void DumpIteratedString(auto string)
-{
-    for(auto c : string)
-        std::cout << c;
-}
-
-void DumpMapEntry(StringName key)
-{
-    bool contained = map.contains(key);
-
-    std::cout << "Key: " << static_cast<int>(key) << ((contained) ? " Found: " : " Not Found\n");
-
-    if(contained) {
-        std::cout << map.get(key) << "\n";
-    }
-}
+static constexpr auto map = squeeze::StringMap<Key, squeeze::HuffmanEncoder>(buildMapStrings);
 
 int main()
 {
-    std::cout << "String Table:\n";
-    for(std::size_t i = 0; i < table.count(); ++i){
-        std::cout << table[i] << "\n";
+  static constexpr auto str1 = map.get(Key::String_1);
+    for (const auto &c : str1) {
+        putc(c);
     }
-
-    std::cout << "\nStringMap:\n";
-
-    DumpMapEntry(StringName::String_1);
-    DumpMapEntry(StringName::String_2);
-    DumpMapEntry(StringName::String_3);
-    DumpMapEntry(StringName::String_4);
-
     return 0;
 }

--- a/include/squeeze/lib/bit_stream.h
+++ b/include/squeeze/lib/bit_stream.h
@@ -4,7 +4,6 @@
 #include <climits>
 #include <cstdint>
 #include <array>
-#include <stdexcept>
 
 namespace squeeze::lib
 {
@@ -26,8 +25,6 @@ namespace squeeze::lib
 
        constexpr void set(std::size_t idx)
        {
-           if(idx >= size())
-               throw std::out_of_range{"bad index"};
 
            auto offset = idx / BitsPerStorageElement;
            auto bit = idx % BitsPerStorageElement;
@@ -38,8 +35,6 @@ namespace squeeze::lib
 
        constexpr void clear(std::size_t idx)
        {
-           if(idx >= size())
-               throw std::out_of_range{"bad index"};
 
            auto offset = idx / BitsPerStorageElement;
            auto bit = idx % BitsPerStorageElement;
@@ -50,8 +45,6 @@ namespace squeeze::lib
 
        constexpr bool at(std::size_t idx) const
        {
-           if(idx >= size())
-               throw std::out_of_range{"bad index"};
 
            auto offset = idx / BitsPerStorageElement;
            auto bit = idx % BitsPerStorageElement;

--- a/include/squeeze/nilencoder.h
+++ b/include/squeeze/nilencoder.h
@@ -3,7 +3,6 @@
 
 #include <string_view>
 #include <array>
-#include <stdexcept>
 
 #include "concepts.h"
 

--- a/include/squeeze/squeeze.h
+++ b/include/squeeze/squeeze.h
@@ -55,8 +55,8 @@ namespace squeeze
                 auto entry = std::lower_bound(m_Lookup.begin(), m_Lookup.end(), key,
                                               [](auto const &e, auto const& v){return e.Key < v;});
 
-                if(entry == m_Lookup.end() || (*entry).Key != key)   // could be larger
-                    throw std::out_of_range{"key not found"};
+            //    if(entry == m_Lookup.end() || (*entry).Key != key)   // could be larger
+             //       throw std::out_of_range{"key not found"};
 
                 return m_Data[(*entry).Index];
             }


### PR DESCRIPTION
DO NOT TAKE THIS AS A SERIOUS PR

The point is to show what I hacked around to get small device (exceptionless) support for reading the strings.

 - iterable_string is now constexpr
 - std::function removed in favor of a captureless lambda
 - move to non-throwing (and non-error handling) access to variant