### PR TITLE
Correct usage of putc/putchar in example

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -11,7 +11,7 @@ enum class Key {
 
 static constexpr auto buildMapStrings = [] {
     return std::to_array<squeeze::KeyedStringView<Key>>({
-      // out of order and missing a value
+      // out of order and missing a key
       { Key::String_3, "There is little point to using short strings in a compressed string table." },
       { Key::String_1, "We will include some long strings in the table to test it." },
     });
@@ -25,9 +25,9 @@ int main()
     // grab the first compressed string and dump it to stdout.
     static constexpr auto str1 = map.get(Key::String_1);
     for (const auto &c : str1) {
-        putc(c, stdout);
+        std::putchar(c);
     }
 
-    putc('\n', stdout);
+    std::putchar('\n');
     return 0;
 }


### PR DESCRIPTION
Use `std::` prefix for `<cstdio>` functions as suggested in Issue #2